### PR TITLE
Type checks using tsc as part of test, providing type definitions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -20,7 +20,7 @@ jobs:
     - name: npm install and test
       run: |
         npm ci
-        npm test --100
+        npm test -- --100
       env:
         CI: true
 #  build-windows:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -23,6 +23,7 @@ jobs:
         npm test -- --100
       env:
         CI: true
+        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 #  build-windows:
 #
 #    runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/karfau/runex/badge.svg)](https://coveralls.io/github/karfau/runex)
+
 # runex
 
 Run module export as a `node` or `npx` script.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,44 @@
+#! /usr/bin/env node
+/**
+ * A Module that exports a method named `run`.
+ */
+export type RunnableModule = NodeModule & {
+    run: Function;
+};
+/**
+ * Available CLI options for runex.
+ *
+ * Usage information: `npx runex -h|--help`
+ */
+export type Options = {
+    require: string[];
+};
+export function collectDistinct(value: string, prev: string[]): string[];
+export namespace ExitCode {
+    export const MissingArgument: number;
+    export const ModuleNotFound: number;
+    export const InvalidModuleExport: number;
+    export const ExportThrows: number;
+}
+export function exitWithUsage(commander: any, code: number): () => never;
+export function parseArguments(argv: string[]): {
+    args: string[];
+    moduleNameOrPath: string;
+    opts: {
+        require: string[];
+    };
+};
+export function requireRunnable(possiblePaths: string[], opts: {
+    require: string[];
+}, _require?: NodeRequire | undefined): NodeModule & {
+    run: Function;
+};
+export function resolveRelativeAndRequirePaths(moduleNameOrPath: string): string[];
+export function run(runnable: NodeModule & {
+    run: Function;
+}, { args }?: {
+    args: any[];
+    opts: {
+        require: string[];
+    };
+} | undefined): Promise<any>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,6 +238,12 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
       "dev": true
     },
+    "@types/node": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.1.0.tgz",
+      "integrity": "sha512-zwrxviZS08kRX40nqBrmERElF2vpw4IUTd5khkhBTfFH8AOaeoLVx48EC4+ZzS2/Iga7NevncqnsUSYjM4OWYA==",
+      "dev": true
+    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "index.d.ts",
   "scripts": {
     "pretest": "npm run --silent tsc; cd examples/num-args; npm --silent run setup; cd -;",
-    "test": "tap --no-coverage",
+    "test": "set; tap --no-coverage",
     "tsc": "npm run tsc:check && npm run tsc:types",
     "tsc:check": "tsc --noEmit --listFiles",
     "tsc:types": "tsc -p tsconfig.types.json5 --emitDeclarationOnly --listEmittedFiles"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "0.2.0",
   "description": "Run module export as a script",
   "bin": "index.js",
+  "types": "index.d.ts",
   "scripts": {
-    "pretest": "cd examples/num-args; npm --silent run setup; cd -;",
-    "test": "tap --no-coverage"
+    "pretest": "npm run --silent tsc; cd examples/num-args; npm --silent run setup; cd -;",
+    "test": "tap --no-coverage",
+    "tsc": "npm run tsc:check && npm run tsc:types",
+    "tsc:check": "tsc --noEmit --listFiles",
+    "tsc:types": "tsc -p tsconfig.types.json5 --emitDeclarationOnly --listEmittedFiles"
   },
   "repository": {
     "type": "git",
@@ -28,10 +32,12 @@
   },
   "homepage": "https://github.com/karfau/runex#readme",
   "devDependencies": {
+    "@types/node": "13.1.0",
     "num-args": "./examples/num-args",
     "tap": "14.10.5",
     "testdouble": "3.12.4",
-    "ts-node": "8.5.4"
+    "ts-node": "8.5.4",
+    "typescript": "3.7.4"
   },
   "dependencies": {
     "commander": "4.0.1"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "types": "index.d.ts",
   "scripts": {
     "pretest": "npm run --silent tsc; cd examples/num-args; npm --silent run setup; cd -;",
-    "test": "set; tap --no-coverage",
+    "test": "tap --100",
+    "test:watch": "tap --no-coverage --watch",
     "tsc": "npm run tsc:check && npm run tsc:types",
     "tsc:check": "tsc --noEmit --listFiles",
     "tsc:types": "tsc -p tsconfig.types.json5 --emitDeclarationOnly --listEmittedFiles"

--- a/test.command.js
+++ b/test.command.js
@@ -33,26 +33,15 @@ export const command = async (cmd, opts) => exec(
  * @param {import('tap').Test} t
  * @param {function(string, string|RegExp, string?): Promise<void>} test
  * @param {string | RegExp} stdoutAssertion
- * @param checkStdErr checking empty stderr can be skipped by setting to `false`
  */
 export const assertStdout = (
-  t, test, stdoutAssertion, checkStdErr = true
+  t, test, stdoutAssertion
 ) =>
   /** @param {CommandResponse} it */
-    ({code, killed, signal, stderr, stdout = 'null'}) => {
-    t.assertNot(killed || signal, `command was killed with '${signal}'`);
+    ({code, killed, signal, stderr, stdout}) => {
+    t.assertNot((killed || signal), `command was killed with '${signal}'`);
     t.assertNot(code, `unexpected exit code '${code}'`);
-    if (checkStdErr) {
-      const stderrSafe = stderr ? stderr.trim() : stderr;
-      stderrSafe && t.equals(
-        stderrSafe,
-        '',
-        `unexpected stderr: "${
-          stderrSafe.split('\n')[0]
-        }${
-          stderrSafe.includes('\n') ? '[...]' : ''
-        }"`
-      );
-    }
+    stderr = stderr.trim();
+    t.equals(stderr, '', `unexpected stderr: "${stderr.split('\n')[0]}[...]"`);
     test(stdout.trim(), stdoutAssertion, 'expected stdout');
   }

--- a/test/option-require.js
+++ b/test/option-require.js
@@ -31,7 +31,7 @@ test('requireRunnable requires from opts.require', async t => {
   td.when(_require('runnable')).thenReturn({run: () => {}})
   const modules = ['a', 'b']
 
-  requireRunnable(['runnable'], {require: modules}, _require)
+  requireRunnable(['runnable'], {require: modules}, /** @type {NodeRequire} */(_require))
 
   t.matches(td.explain(_require).calls.map(it => it.args[0]), [...modules, 'runnable'])
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,74 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "ES2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "none",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    "allowJs": true,                       /* Allow javascript files to be compiled. */
+    "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+     "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  },
+  "include": [
+    "index.js",
+    "test.*.js",
+    "test/**/*.js",
+    "examples/**/*.js",
+    "examples/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/tsconfig.types.json5
+++ b/tsconfig.types.json5
@@ -1,0 +1,14 @@
+{
+  "extends": ".",
+  "compilerOptions": {
+    "declaration": true,
+    "noEmit": false,
+    "removeComments": false
+  },
+  "include": [
+    "index.js"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
Changes in package.json:
- `devDependencies`:
  - `@types/node`
  - (from implicit to explicit:) `ts-node`, `typescript`
- `scripts`
  - `tsc` (= `tsc:check` & `tsc:types`)
  - `pretest`: added `tsc` as first step

Code changes are related to problems tsc found.

Coverage check was not working on github actions, fixed it and added coveralls.io integration.