### PR TITLE
fix(--require): Resolve project local modules in npx context

### DIFF
--- a/examples/npx-require/.gitignore
+++ b/examples/npx-require/.gitignore
@@ -1,0 +1,1 @@
+package-lock.json

--- a/examples/npx-require/package.json
+++ b/examples/npx-require/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@runex/test-npx",
+  "description": "An example of a package that is made runnable and uses runex as a devDependency.",
+  "private": true,
+  "version": "0.0.0",
+  "main": "num-args.js",
+  "devDependencies": {
+    "rimraf": "latest",
+    "ts-node": "latest"
+  },
+  "scripts": {
+    "clear": "rimraf node_modules",
+    "setup": "npm --silent run clear && npm --silent install --no-save --no-audit",
+    "test": "npx -q ../../runex.tgz -r ts-node/register sum 1 2"
+  }
+}

--- a/examples/npx-require/sum.ts
+++ b/examples/npx-require/sum.ts
@@ -1,0 +1,10 @@
+/**
+ * Requires ts-node for being runnable which can be added by calling
+ *
+ * `npx runex -r ts-node/register examples/sum.ts` => 0
+ * `npx runex -r ts-node/register examples/sum.ts 1 2.5` => 3.5
+ *
+ */
+export const run = (...args: string[]) => {
+  return args.map(parseFloat).reduce((sum, cur) => sum + cur, 0);
+};

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ const requireRunnable = (
   possiblePaths, opts, _require = require
 ) => {
   for (const hook of opts.require) {
-    _require(hook)
+    _require(_require.resolve(hook, {paths: ['.']}));
   }
 
   const errors = []

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "index.d.ts"
   ],
   "scripts": {
-    "clear": "npx rimraf coverage .nyc_output ",
+    "clear": "npx rimraf coverage .nyc_output runex-*.tgz",
     "clear:all": "npm run clear -- node_modules examples/num-args/node_modules",
-    "pretest": "npm run --silent tsc && cd examples/num-args && npm --silent run setup && cd -",
+    "pretest": "npm run --silent clear && npm run --silent tsc && npm run --silent pretest:num-args && npm run --silent pretest:npx-require",
+    "pretest:num-args": "cd examples/num-args && npm --silent run setup && cd -",
+    "pretest:npx-require": "npm pack && mv runex-*.tgz runex.tgz && cd examples/npx-require && npm --silent run setup && cd -",
     "test": "tap --reporter=tap --100 ",
     "dev": "tap --coverage --watch",
     "codecov": "tap --coverage-report=text-lcov | codecov --pipe --disable=gcov -t \"$CODECOV_TOKEN\"",

--- a/test/npx-integration.js
+++ b/test/npx-integration.js
@@ -4,8 +4,6 @@ import { test } from 'tap'
 
 import { assertStdout, command } from '../test.command'
 
-const cwd = './examples/num-args'
-
 /**
  * Checking npx integration:
  * Since we want to test the current code (not what npx would install from npm),
@@ -17,20 +15,23 @@ const cwd = './examples/num-args'
  * Since I was not able to run `npm i` as part of the test,
  * it is currently configured in `pretest`.
  *
+ * @see examples/npx-require
  * @see examples/num-args
  */
-/*
-test(`${cwd} setup`, async t => {
-  return command('npm setup', {cwd}).then(it => {
-    t.equals(it.stderr.trim(), '', 'stderr should be empty');
-    t.assertNot(it.code, 'npm install exit code');
-    console.log('1st stdout', it.stdout);
-  });
-  t.ok(existsSync(join(cwd, 'node_modules')), 'node_modules existing');
-});
-*/
 
 test('"npx runex" works as expected', async t => {
-  t.ok(existsSync(join(cwd, 'node_modules')), `${cwd}/node_modules existing`);
-  return command('npx runex ./num-args.js a b', {cwd}).then(assertStdout(t, t.match, '2'));
+  t.ok(
+    existsSync(join('examples', 'num-args', 'node_modules')),
+    `./examples/num-args/node_modules existing`
+  );
+  return command(
+    'npx runex ./num-args.js a b', {cwd: 'examples/num-args'}
+  ).then(assertStdout(t, t.match, '2'));
+})
+
+test('"npx runex -r ts-node/register" works when ts-node is installed in local node-modules', async t => {
+  t.ok(existsSync('runex.tgz'), 'runex.tgz existing');
+  return command(
+    'npm run test', {cwd: 'examples/npx-require'}
+  ).then(assertStdout(t, t.match, '2'));
 })

--- a/test/option-require.js
+++ b/test/option-require.js
@@ -27,13 +27,20 @@ test('parseArguments provides opts.require', async t => {
 })
 
 test('requireRunnable requires from opts.require', async t => {
+
   const _require = td.func('_require')
+  _require['resolve'] = td.func('_require.resolve')
   td.when(_require('runnable')).thenReturn({run: () => {}})
   const modules = ['a', 'b']
+  modules.forEach((hook) => {
+    td.when(_require['resolve'](hook, {paths: ['.']})).thenReturn(`resolved/${hook}`)
+  })
 
   requireRunnable(['runnable'], {require: modules}, /** @type {NodeRequire} */(_require))
 
-  t.matches(td.explain(_require).calls.map(it => it.args[0]), [...modules, 'runnable'])
+  t.matches(td.explain(_require).calls.map(it => it.args[0]), [
+    ...modules.map(hook => `resolved/${hook}`), 'runnable'
+  ])
 })
 
 test('invalid options', async t => {


### PR DESCRIPTION
When executing a local TypeScript module and using `--require=ts-node/register` option,
node was trying to resolve it inside the temporary npx folder.
This behaviour doesn't currently make sense, now modules required via this option
are always resolved relative from the current working directory of the script.
This currently prevents requiring a module that only exists in the npx context, but that could be added back easily if needed.

https://nodejs.org/docs/latest-v10.x/api/all.html#modules_require_resolve_request_options